### PR TITLE
Drop Support for Python 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cdo]
 .cache
 .env
+.pytest_cache
 .tox
 coverage
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,5 @@ matrix:
       env: TOXENV=py35 TRAVIS=yes
     - python: 3.4
       env: TOXENV=py34 TRAVIS=yes
-    - python: 3.3
-      env: TOXENV=py33 TRAVIS=yes
     - python: 2.7
       env: TOXENV=py27 TRAVIS=yes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,8 +23,8 @@ sys.path.insert(0, src_path)
 project = u'decafjoe-safe'
 copyright = u'2016-2018, Joe Joyce and contributors'
 author = u'Joe Joyce'
-version = u'0.6'
-release = u'0.6.4'
+version = u'0.7'
+release = u'0.7.0'
 
 # Paths
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/req/env.txt
+++ b/req/env.txt
@@ -1,6 +1,6 @@
 -r lint.txt
 -r test.txt
-sphinx==1.7.4
-sphinx_rtd_theme==0.3.0
+sphinx==1.7.5
+sphinx_rtd_theme==0.4.0
 tox==3.0.0
 twine==1.11.0

--- a/req/lint.txt
+++ b/req/lint.txt
@@ -4,7 +4,7 @@ flake8-commas==2.0.0
 flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
 flake8-import-order==0.17.1
-flake8-ownership==1.1.1
+flake8-ownership==2.0.0
 flake8-quotes==1.0.0
 flake8-todo==0.7
-pep8-naming==0.5.0
+pep8-naming==0.7.0

--- a/req/test.txt
+++ b/req/test.txt
@@ -1,3 +1,3 @@
 coverage==4.5.1
 mock==2.0.0
-pytest==3.2.5
+pytest==3.6.2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ requires = (
     'clik==0.92.2',
     'clik-shell==0.90.0',
     'clik-wtforms==0.90.1',
-    'sqlalchemy==1.2.7',
-    'wtforms==2.1',
+    'sqlalchemy==1.2.8',
+    'wtforms==2.2.1',
 )
 
 url = 'https://%s.readthedocs.io' % name

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import find_packages, setup
 
 
 name = 'decafjoe-safe'
-version = '0.6.4'
+version = '0.7.0'
 requires = (
     'clik==0.92.2',
     'clik-shell==0.90.0',

--- a/src/safe/__init__.py
+++ b/src/safe/__init__.py
@@ -12,7 +12,7 @@ import sys
 #: Version of the program.
 #:
 #: :type: :class:`str`
-__version__ = '0.6.4'
+__version__ = '0.7.0'
 
 
 def main(argv=None, exit=sys.exit):

--- a/src/safe/app.py
+++ b/src/safe/app.py
@@ -113,7 +113,7 @@ def safe():
 
     password = None
     if gpg_file.symmetric:
-        password = getpass.getpass()
+        password = getpass.getpass('Master password: ')
 
     try:
         with temporary_directory() as tmp:

--- a/src/test/test_gpg/files/trustdb.txt
+++ b/src/test/test_gpg/files/trustdb.txt
@@ -1,3 +1,1 @@
-# List of assigned trustvalues, created Mon Nov 13 13:22:04 2017 EST
-# (Use "gpg --import-ownertrust" to restore them)
 81A375A2DC9B70881F65402F5DF95704FE4FD2BC:6:

--- a/tool/post-release
+++ b/tool/post-release
@@ -49,4 +49,4 @@ xpsed "s/$search/$replace/" "$root_dir/doc/conf.py"
 git tag $current_version
 git add "$root_dir/setup.py" "$root_dir/doc/conf.py" "$version_file"
 git commit -m "Bumps version from $current_version to $version after release."
-git push --tags --no-verify github master
+git push --tags --no-verify hub master

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, pypy3, cover, lint
+envlist = py27, py34, py35, py36, pypy, pypy3, cover, lint
 
 [testenv]
 deps = -r{toxinidir}/req/test.txt


### PR DESCRIPTION
The major item in these commits is the dropping of Python 3.3 support. See the commit message on 
0718a6d for more information.

The other notable change is the updating of dependencies to their latest versions.